### PR TITLE
improve example html. Add protocol field to proof output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ be used directly with this library.
 node ../tools/buildpkey.js -i proving_key.json -o proving_key.bin
 ```
 
-The result is a JSON object with pi_a, pi_b and pi_c points.
+The result is a JSON object with pi_a, pi_b, pi_c points and protocol groth field.
 
 You can use the stringified version of this JSON as a proof.json in [snarkjs](https://github.com/iden3/snarkjs)
 
@@ -62,20 +62,24 @@ Here is a simple example of a web page that loads a key and a witness and genera
 <script>
 
 var witness;
-var proving_key;
+var provingKey;
 
 function onLoad() {
-
+    document.getElementById("calcProof").disabled = true;
     fetch("proving_key.bin").then( (response) => {
         return response.arrayBuffer();
     }).then( (b) => {
         provingKey = b;
-    });
-
-    fetch("witness.bin").then( (response) => {
-        return response.arrayBuffer();
-    }).then( (b) => {
-        witness = b;
+        console.log("proving key loaded");
+    }).then( () =>{ 
+        fetch("witness.bin").then( (response) => {
+          return response.arrayBuffer();
+        }).then( (b) => {
+          witness = b;
+        }).then ( () => {
+          console.log("witness loaded");
+          document.getElementById("calcProof").disabled = false;
+        });
     });
 }
 
@@ -96,7 +100,7 @@ function calcProof() {
 <body onLoad="onLoad()">
 <h1>iden3</h1>
 <h2>Zero knowledge proof generator</h2>
-<button onClick="calcProof()">Test</button>
+<button id="calcProof" onClick="calcProof()">Test</button>
 <div id="time"></div>
 <pre id="proof"></pre>
 

--- a/build/websnark.js
+++ b/build/websnark.js
@@ -1572,6 +1572,10 @@ function thread(self) {
         while (i32[0] & 3) i32[0]++;  // Return always aligned pointers
         const res = i32[0];
         i32[0] += length;
+        while (i32[0] > memory.buffer.byteLength) {
+          memory.grow(100);
+        }
+        i32 = new Uint32Array(memory.buffer);
         return res;
     }
 
@@ -2099,6 +2103,7 @@ class Groth16 {
             pi_a: this.bin2g1(this.getBin(pi_a, 96)),
             pi_b: this.bin2g2(this.getBin(pi_b, 192)),
             pi_c: this.bin2g1(this.getBin(pi_c, 96)),
+            protocol: 'groth',
         };
 
     }
@@ -3378,7 +3383,6 @@ function fromByteArray (uint8) {
 }
 
 },{}],10:[function(require,module,exports){
-(function (Buffer){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -5157,8 +5161,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-}).call(this,require("buffer").Buffer)
-},{"base64-js":9,"buffer":10,"ieee754":11}],11:[function(require,module,exports){
+},{"base64-js":9,"ieee754":11}],11:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1

--- a/example/index.html
+++ b/example/index.html
@@ -8,17 +8,21 @@ var witness;
 var provingKey;
 
 function onLoad() {
-
+    document.getElementById("calcProof").disabled = true;
     fetch("proving_key.bin").then( (response) => {
         return response.arrayBuffer();
     }).then( (b) => {
         provingKey = b;
-    });
-
-    fetch("witness.bin").then( (response) => {
-        return response.arrayBuffer();
-    }).then( (b) => {
-        witness = b;
+        console.log("proving key loaded");
+    }).then( () =>{ 
+        fetch("witness.bin").then( (response) => {
+          return response.arrayBuffer();
+        }).then( (b) => {
+          witness = b;
+        }).then ( () => {
+          console.log("witness loaded");
+          document.getElementById("calcProof").disabled = false;
+        });
     });
 }
 
@@ -75,7 +79,7 @@ function test() {
 <body onLoad="onLoad()">
 <h1>iden3</h1>
 <h2>Zero knowledge proof generator</h2>
-<button onClick="calcProof()">Test</button>
+<button id="calcProof" onClick="calcProof()">Test</button>
 <div id="time"></div>
 <pre id="proof"></pre>
 

--- a/example/websnark.js
+++ b/example/websnark.js
@@ -1572,6 +1572,10 @@ function thread(self) {
         while (i32[0] & 3) i32[0]++;  // Return always aligned pointers
         const res = i32[0];
         i32[0] += length;
+        while (i32[0] > memory.buffer.byteLength) {
+          memory.grow(100);
+        }
+        i32 = new Uint32Array(memory.buffer);
         return res;
     }
 
@@ -2099,6 +2103,7 @@ class Groth16 {
             pi_a: this.bin2g1(this.getBin(pi_a, 96)),
             pi_b: this.bin2g2(this.getBin(pi_b, 192)),
             pi_c: this.bin2g1(this.getBin(pi_c, 96)),
+            protocol: 'groth',
         };
 
     }
@@ -3378,7 +3383,6 @@ function fromByteArray (uint8) {
 }
 
 },{}],10:[function(require,module,exports){
-(function (Buffer){
 /*!
  * The buffer module from node.js, for the browser.
  *
@@ -5157,8 +5161,7 @@ function numberIsNaN (obj) {
   return obj !== obj // eslint-disable-line no-self-compare
 }
 
-}).call(this,require("buffer").Buffer)
-},{"base64-js":9,"buffer":10,"ieee754":11}],11:[function(require,module,exports){
+},{"base64-js":9,"ieee754":11}],11:[function(require,module,exports){
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
   var eLen = (nBytes * 8) - mLen - 1

--- a/src/groth16.js
+++ b/src/groth16.js
@@ -599,6 +599,7 @@ class Groth16 {
             pi_a: this.bin2g1(this.getBin(pi_a, 96)),
             pi_b: this.bin2g2(this.getBin(pi_b, 192)),
             pi_c: this.bin2g1(this.getBin(pi_c, 96)),
+            protocol: 'groth',
         };
 
     }


### PR DESCRIPTION
- example
  - show browser console `proving key loaded` and `witness loaded` when `proving_key.bin` and `witness.bin` are loaded
  - disable `calcProof` button until files are loaded
- src/groth16.js
  - add `protocol`:`groth` field to object returned
  - needed when call `snarkjs generatecall` since it uses `proof.json` and protocol should be defined